### PR TITLE
Fix race conditions in mock server

### DIFF
--- a/gohttp_mock/client.go
+++ b/gohttp_mock/client.go
@@ -26,7 +26,9 @@ func (c httpClientMock) Do(request *http.Request) (*http.Response, error) {
 	}
 
 	var response = http.Response{}
+	MockupServer.serverMutex.RLock()
 	mock := MockupServer.mocks[MockupServer.getMockKey(request.Method, request.URL.String(), string(body))]
+	MockupServer.serverMutex.RUnlock()
 	if mock != nil {
 		if mock.Error != nil {
 			return nil, mock.Error

--- a/gohttp_mock/mock_server.go
+++ b/gohttp_mock/mock_server.go
@@ -17,7 +17,7 @@ var (
 
 type mockServer struct {
 	enabled     bool
-	serverMutex sync.Mutex
+	serverMutex sync.RWMutex
 
 	httpClient core.HttpClient
 
@@ -39,6 +39,9 @@ func (m *mockServer) Stop() {
 }
 
 func (m *mockServer) IsEnabled() bool {
+	m.serverMutex.RLock()
+	defer m.serverMutex.RUnlock()
+
 	return m.enabled
 }
 

--- a/gohttp_mock/mock_server_test.go
+++ b/gohttp_mock/mock_server_test.go
@@ -1,0 +1,54 @@
+package gohttp_mock
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestMockServer_IsEnabledConcurrentAccess(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 0; j < 100; j++ {
+				_ = MockupServer.IsEnabled()
+			}
+			wg.Done()
+		}()
+	}
+	for i := 0; i < 100; i++ {
+		if i%2 == 0 {
+			MockupServer.Start()
+		} else {
+			MockupServer.Stop()
+		}
+	}
+	wg.Wait()
+}
+
+func TestHttpClientMockConcurrentMapAccess(t *testing.T) {
+	MockupServer.DeleteMocks()
+	MockupServer.Start()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(id int) {
+			for j := 0; j < 10; j++ {
+				req, _ := http.NewRequest(http.MethodGet, "https://example.com", strings.NewReader(""))
+				_, _ = MockupServer.GetMockedClient().Do(req)
+			}
+			wg.Done()
+		}(i)
+	}
+
+	for i := 0; i < 50; i++ {
+		MockupServer.AddMock(Mock{Method: http.MethodGet, Url: "https://example.com"})
+		MockupServer.DeleteMocks()
+	}
+
+	wg.Wait()
+	MockupServer.Stop()
+}


### PR DESCRIPTION
## Summary
- guard mock server `enabled` flag with RWMutex
- protect mock map access in http client mock
- add tests covering concurrent access to mock server
- use public client getter in tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6857f4be652c8330b72f14d84cec69d4